### PR TITLE
save lolversion for later use in plugins

### DIFF
--- a/plugins/ugg.js
+++ b/plugins/ugg.js
@@ -63,11 +63,7 @@ const u = {
 };
 
 // KEY CONSTS - UPDATE THESE ACCORDING TO GUIDE https://gist.github.com/paolostyle/fe8ce06313d3e53c134a24762b9e519c
-const uGGDataVersion = '1.2';
 const uGGAPIVersion = '1.1';
-
-const riotVersionEndpoint = 'https://ddragon.leagueoflegends.com/api/versions.json';
-const uGGDataVersionsEndpoint = 'https://u.gg/json/new_ugg_versions/' + uGGDataVersion + '.json';
 
 const server = u.servers.world;
 const tier = u.tiers.platPlus;
@@ -113,17 +109,10 @@ function extractPage(champion) {
 
 async function getDataSource(champion) {
   try {
-    const lolVersions = await getJson(riotVersionEndpoint);
-
-    let lolVersion = lolVersions[0];
+    let lolVersion = freezer.get().lolversion;
     let lolVersionUGG = getUGGFormattedLolVersion(lolVersion);
-
+    
     const overviewVersion = "1.4.0";
-
-    // This here will hopefully not stay for long, i just don't yet know a way to get the static data version u.gg uses)
-    // In fact, now that i think of it, i will just add a way to cache champId's at some point, then we dont need this at all
-    // const staticPatchOverride = "9.19.1";
-
     const championDataUrl = `https://static.u.gg/assets/lol/riot_static/${lolVersion}/data/en_US/champion.json`;
 
     const championData = await getJson(championDataUrl);

--- a/src/app.js
+++ b/src/app.js
@@ -86,6 +86,7 @@ request('https://ddragon.leagueoflegends.com/api/versions.json', function (error
 freezer.on('version:set', (ver) => {
 	request('http://ddragon.leagueoflegends.com/cdn/'+ver+'/data/en_US/champion.json', function(error, response, data) {
 		if(!error && response && response.statusCode == 200){
+			freezer.get().set('lolversion', ver);
 			freezer.get().set('championsinfo', JSON.parse(data).data);
 			freezer.emit("championsinfo:set");
 		}

--- a/src/state.js
+++ b/src/state.js
@@ -56,6 +56,8 @@ var state = {
 
 	championsinfo: {},
 
+	lolversion: '',
+
 	champselect: false,
 	autochamp: false,
 


### PR DESCRIPTION
This prevented double requests. Since some plugins and possibly the tool itself might need this info later.

Besides, I have removed some old burdens from u.gg