### PR TITLE
optimization at the lcu-api

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -419,6 +419,7 @@ connector.on('connect', (data) => {
 connector.on('disconnect', () => {
 	console.log("client closed");
 	api.destroy();
+	freezer.get().connection.set({ page: null, summonerLevel: 0 });
 	freezer.get().session.set({ connected: false, state: "" });
 	freezer.get().set("champselect", false);
 });

--- a/src/lcu-api.js
+++ b/src/lcu-api.js
@@ -4,6 +4,15 @@ const request = require('request');
 var ws = null;
 var conn_data = null;
 
+// messages we listen to
+var message_filter = [
+    '/lol-champ-select/v1/session:Delete',
+	'/lol-champ-select/v1/session:Update',
+	'/lol-perks/v1/currentpage:Update',
+	'/lol-perks/v1/perks:Update',
+	'/lol-summoner/v1/current-summoner:Update'
+];
+
 function bind(data) {
 	conn_data = data;
 	ws = new WebSocket(`wss://${data.username}:${data.password}@${data.address}:${data.port}/`, "wamp", {
@@ -31,10 +40,14 @@ function bind(data) {
 			console.log("connected", res);
 			freezer.emit(`api:connected`);
 		}
-		if(res[1] == "OnJsonApiEvent") {
+		if(res[1] == "OnJsonApiEvent") {	
 			var evt = res[2];
-			//console.log(`${evt.uri}:${evt.eventType}`);
-			freezer.emit(`${evt.uri}:${evt.eventType}`, evt.data);
+			var url = `${evt.uri}:${evt.eventType}`;
+
+			if (message_filter.includes(url)){
+				//console.log(url);
+				freezer.emit(`${evt.uri}:${evt.eventType}`, evt.data);
+			}
 		}
 	});
 
@@ -52,6 +65,9 @@ var methods = {};
 ["post", "put", "get", "del"].forEach(function(method) {
 	methods[method] = function(endpoint, body) {
 		return new Promise(resolve => {	
+			if(ws == null)
+				return;
+
 			var options = {
 				url: `${conn_data.protocol}://${conn_data.address}:${conn_data.port}${endpoint}`,
 				auth: {


### PR DESCRIPTION
- reset current rune page when the client is closed
- Limit messages for which an event is fired (feels almost like 90% less events)
- avoid errors when a function tries to send something to the api while no websocket is open (hello autochampselect checkbox)