### PR TITLE
fix findTooltip on missing perks

### DIFF
--- a/tags/page-list.tag
+++ b/tags/page-list.tag
@@ -64,6 +64,7 @@
     findTooltip(page, index) {
       if(!opts.tooltips.rune) return;
       var tooltip = opts.tooltips.rune.find((el) => el.id === parseInt(page.selectedPerkIds[index]));
+      if(!tooltip) return;
       return '<b>' + tooltip.name + '</b><br>' + tooltip.longDesc;
     }
 


### PR DESCRIPTION
Fixes an error in "findTooltip" if a rune was not found (e.g. Runforge)

Currently 3 errors are thrown for each page. Since no stat updates are found.