### PR TITLE
Automatic theme determination at first start

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,11 @@
 var settings = require('./settings');
 var freezer = require('./state');
 
+if(settings.get("darktheme") == null){
+	const { nativeTheme } = require('electron').remote.require('electron')
+	settings.set("darktheme", nativeTheme.shouldUseDarkColors ?? false);
+}
+
 freezer.get().configfile.set({
 	name: settings.get("config.name") + settings.get("config.ext"),
 	cwd: settings.get("config.cwd"),

--- a/src/settings.js
+++ b/src/settings.js
@@ -14,7 +14,7 @@ settings = new Store({
 		pathdiscovery: true,
 		autochamp: false,
 		lasttab: "local",
-		darktheme: false,
+		darktheme: null,
 	}
 });
 


### PR DESCRIPTION
Determines at the first start which color should be used.

That means if in Windows/Mac/Linux you determine that a dark theme should be used, the default is set to True and reversed.

For existing users this does not change anything. But users who start Runebook for the first time will get the right layout directly.