### PR TITLE
Fix pagename overflow and change pagelist layout to flexbox

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -2,6 +2,29 @@ body {
 	background: #191D24;
 }
 
+.runepage.list > .item {
+	display: flex !important;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.runepage.list > .item > .runeimages {
+	flex: 0 0 auto;
+	order: 1;
+}
+
+.runepage.list > .item > .pagename {
+	flex: 1 1 auto;
+	padding: 0 1em;
+	order: 2;
+}
+
+.runepage.list > .item > .buttons {
+	flex: 0 0 auto;
+	order: 3;
+}
+
 .ui.secondary.pointing.menu {
 	background: #121212;
 	border-bottom: 1px solid #BD9D5E;

--- a/light.css
+++ b/light.css
@@ -2,6 +2,29 @@ body {
 	background: #ffffff;
 }
 
+.runepage.list > .item {
+	display: flex !important;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.runepage.list > .item > .runeimages {
+	flex: 0 0 auto;
+	order: 1;
+}
+
+.runepage.list > .item > .pagename {
+	flex: 1 1 auto;
+	padding: 0 1em;
+	order: 2;
+}
+
+.runepage.list > .item > .buttons {
+	flex: 0 0 auto;
+	order: 3;
+}
+
 .ui.secondary.pointing.menu {
 	background: #ffffff;
 	border-bottom: 1px solid #BD9D5E;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "request-promise-native": "^1.0.8",
     "riot": "^3.13.2",
     "riot-i18n": "^0.2.1",
-    "semantic-ui-css": "~2.3.0",
+    "semantic-ui-css": "^2.4.1",
     "ws": "^7.3.0"
   },
   "devDependencies": {

--- a/tags/current-page.tag
+++ b/tags/current-page.tag
@@ -15,24 +15,23 @@
 					</div>
 				</div>
 			</div>
-			<div if={ opts.connection.page } class="ui middle aligned relaxed divided list">
+			<div if={ opts.connection.page } class="ui middle aligned relaxed divided runepage list">
 				<div class="item">
-					<div class="right floated content" data-key={ key }>
-
+					<div class="buttons" data-key={ key }>
 						<button class={ (opts.current.champion && opts.connection.page && opts.plugins.local[opts.tab.active]) ? "ui icon button" : "ui icon button disabled"} onclick={ downloadCurrentPage } data-tooltip="{ i18n.localise('currentpage.downloadcurrentpage') }" data-position="left center" data-inverted="">
 							<i class="download icon"></i>
 						</button>
 					</div>
 
-					<div class="ui image">
+
+					<div class="ui runeimages">
 						<div each={ index in [0,1,2,3,4,5,6,7,8] } class="ui circular icon button tooltip current-page-tooltip" style="margin: 0; padding: 0; background-color: transparent; cursor: default;"
 						data-html={findTooltip(index)}>
 							<img draggable="false" class="ui mini circular image" src=./img/runesReforged/perk/{(opts.connection.page && opts.connection.page.selectedPerkIds[index] && opts.connection.page.selectedPerkIds[index] !== -1) ? opts.connection.page.selectedPerkIds[index] : "qm"}.png>
 						</div>
 					</div>
 
-					
-					<div class="middle aligned content">
+					<div class="pagename">
 						<i class={ opts.connection.page ? (!opts.connection.page.isEditable || opts.connection.summonerLevel < 10 ? "lock icon" : (opts.connection.page.isValid ? "" : "red warning sign icon")) : "" }></i> {opts.connection.page ? opts.connection.page.name : ""}
 					</div>
 				</div>

--- a/tags/page-list.tag
+++ b/tags/page-list.tag
@@ -18,10 +18,9 @@
     </virtual>
   </h2>
 
-  <div if={ opts.current.champion } class="ui middle aligned relaxed divided list" style="height: 100%; overflow-y: auto;">
+  <div if={ opts.current.champion } class="ui middle aligned relaxed divided runepage list" style="height: 100%;">
     <div class="item" each={ page, key in opts.current.champ_data.pages }>
-      <div class="right floated content" data-key={ key }>
-        
+      <div class="buttons" data-key={ key }>
         <div class={ opts.connection.page && opts.connection.page.isEditable && opts.connection.summonerLevel >= 10 ? "ui icon button" : "ui icon button disabled" } data-key={key} onclick={ uploadPage } data-tooltip={ i18n.localise('pagelist.uploadpage') } data-position="left center" data-inverted="">
           <i class={ opts.lastuploadedpage.page == key && opts.lastuploadedpage.champion == opts.current.champion ? (opts.lastuploadedpage.loading ? "notched circle loading icon" : (opts.lastuploadedpage.valid === false ? "warning sign icon" : "checkmark icon")) : "upload icon" } data-key={key}></i>
         </div>
@@ -42,13 +41,19 @@
           <i class={opts.lastbookmarkedpage.page == key && opts.lastbookmarkedpage.champion == opts.current.champion ? "checkmark icon" : "bookmark icon"} data-key={key}></i>
         </div>
       </div>
-      <div class="ui image">
+
+      <div class="runeimages">
         <div each={ index in [0,1,2,3,4,5,6,7,8] } class="ui circular icon button tooltip page-list-tooltip" style="margin: 0; padding: 0; background-color: transparent; cursor: default;"
         data-html={findTooltip(page, index)}>
           <img draggable="false" class="ui mini circular image" src=./img/runesReforged/perk/{(page.selectedPerkIds[index] && page.selectedPerkIds[index] !== -1) ? page.selectedPerkIds[index] : "qm"}.png>
         </div>
       </div>
-      <div class="middle aligned content"><i class={ page.isValid === false ? "red warning sign icon" : "" }></i> {key}</div>
+
+      <div class="pagename">
+        <i class={ page.isValid === false ? "red warning sign icon" : "" }></i> {key}
+      </div>
+
+
     </div>
   </div>
 


### PR DESCRIPTION
There was an annoying problem with long pagenames, especially from op.gg (if you have 3 buttons).

### Before
![21_13-RuneBook](https://user-images.githubusercontent.com/48414047/83554924-28c3b700-a516-11ea-88bb-f9aec4a10d95.png)

### After
![21_11-RuneBook](https://user-images.githubusercontent.com/48414047/83554921-27928a00-a516-11ea-9fc5-85e10d1250c7.png)

This PR fixes it, provides more controllable layout, and protects against possible semantic-ui issues, such as #30 
