### PR TITLE
Show changelog modal after update to new version

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -295,3 +295,40 @@ page-list ::-webkit-scrollbar-thumb:hover {
 	border-top: 1px solid #71552B !important;
 	box-shadow: none !important;
 }
+
+.changelog-modal > .header {
+	background: #191D24 !important;
+	color: #bd9d5e !important;
+	border-bottom-color: #bd9d5e !important;
+	text-align: center;
+}
+
+.changelog-modal > .content {
+	background: #191D24 !important;
+	color: #d8cfbd !important;
+}
+
+.changelog-modal > .content > img {
+	width: 66% !important;
+}
+
+.changelog-modal .ui.horizontal.divider {
+	color: #bd9d5e !important;
+}
+
+.changelog-modal .icon {
+	color: #d8cfbd !important;
+}
+
+.ui.modal .scrolling::-webkit-scrollbar-track {
+	background: none !important;
+}
+
+.ui.modal .scrolling::-webkit-scrollbar-thumb,
+.ui.modal .scrolling::-webkit-scrollbar-thumb:window-inactive {
+	background: rgba(255, 255, 255, 0.1) !important;
+}
+
+.ui.modal .scrolling::-webkit-scrollbar-thumb:hover {
+	background: rgba(255, 255, 255, 0.15) !important;
+}

--- a/light.css
+++ b/light.css
@@ -211,3 +211,39 @@ page-list ::-webkit-scrollbar-thumb:hover {
 	border-top: 1px solid #BD9D5E !important;
 	box-shadow: none !important;
 }
+
+.changelog-modal > .header {
+	background: #ffffff !important;
+	color: #000000de !important;
+	text-align: center;
+}
+
+.changelog-modal > .content {
+	background: #ffffff !important;
+	color: #000000de !important;
+}
+
+.changelog-modal > .content > img {
+	width: 66% !important;
+}
+
+.changelog-modal .ui.horizontal.divider {
+	color: #191D24 !important;
+}
+
+.changelog-modal .icon {
+	color: #191D24 !important;
+}
+
+.ui.modal .scrolling::-webkit-scrollbar-track {
+	background: none !important;
+}
+
+.ui.modal .scrolling::-webkit-scrollbar-thumb,
+.ui.modal .scrolling::-webkit-scrollbar-thumb:window-inactive {
+	background: rgba(0, 0, 0, .25) !important;
+}
+
+.ui.modal .scrolling::-webkit-scrollbar-thumb:hover {
+	background: rgba(0, 0, 0, .15) !important;
+}

--- a/src/app.js
+++ b/src/app.js
@@ -76,7 +76,7 @@ freezer.on("changelog:ready", () => {
 	var appVersion = require('electron').remote.app.getVersion();
 	console.log(appVersion, settings.get("changelogversion"))
 	if(settings.get("changelogversion") != appVersion) {
-		// freezer.get().set("showchangelog", true);
+		freezer.get().set("showchangelog", true);
 		settings.set("changelogversion", appVersion);
 	}
 });

--- a/tags/changelog-modal.tag
+++ b/tags/changelog-modal.tag
@@ -6,13 +6,14 @@
       <i1-8n>whatsnew.title</i1-8n> { require('electron-is-dev') === true ? "DEV" : require('electron').remote.app.getVersion(); }
     </div>
     <div class="scrolling content">
-      <img class="ui fluid rounded image" src="./img/backdrop.png">
-      <h3>Greetings, Summoner!</h3>
-      <p>RuneBook has been updated to version { require('electron-is-dev') === true ? "DEV" : require('electron').remote.app.getVersion(); }</p>
+      <img class="ui fluid rounded centered image" src="./img/backdrop.png">
+      <h3 class="ui section horizontal divider">Greetings, Summoner!</h3>
+      <h4 class="centered">RuneBook has been updated to version { require('electron-is-dev') === true ? "DEV" : require('electron').remote.app.getVersion(); }</h4>
 
-      <h3>You can read about new features and bugfixes on our <a href="https://github.com/Soundofdarkness/RuneBook/releases">download page at Github</a></h3>
+      <p>You can read about new features and bugfixes on our <a href="https://github.com/Soundofdarkness/RuneBook/releases">download page at Github</a></p>
 
-      <br><hr><br>
+      <div class="ui divider"></div>
+
       <p>Remember, RuneBook is pretty much complete for what it has to offer, but new small features might be added from time to time, and it will still be updated to support the latest game patch.</p>
       <h4 class="ui header right floated"><a href="https://github.com/Soundofdarkness/RuneBook">RuneBook community</a></h4>
     </div>

--- a/tags/changelog-modal.tag
+++ b/tags/changelog-modal.tag
@@ -8,18 +8,13 @@
     <div class="scrolling content">
       <img class="ui fluid rounded image" src="./img/backdrop.png">
       <h3>Greetings, Summoner!</h3>
-      <p>Is it meta? Preseason is here with the new changes to Runes!</p>
+      <p>RuneBook has been updated to version { require('electron-is-dev') === true ? "DEV" : require('electron').remote.app.getVersion(); }</p>
 
-      <h4 class="ui header">Stat shards
-        <div class="sub header">statistics are now independent from the runes you choose</div></h4>
-      <p>Support for stat shards has been added. Note: if you have old pages that don't support stat shards, RuneBook will automatically fill the missing slots with a default set of stat shards (Adaptive Force, Armor, Magic Resist) when you upload them to the client. You can customize them in the client afterwards. Also RuneBook will support external sites as soon they will update their pages. Just give me some time to adapt the plugins to the new data. Preseason is here for a reason, the situation will be unstable for a while :)</p>
-      <h4>Even more languages</h4>
-      <p>The number of languages that RuneBook support is always increasing thanks to <a href="https://discordapp.com/invite/hN4kP7n">our community</a>.</p>
-      <h4>Reconnect issues</h4>
-      <p>A button has been added to quickly reload RuneBook in case it doesn't recognize the League client. I have also pushed a small fix for some connection issues, but I still need to investigate on that to be sure I'm covering all the cases.</p>
+      <h3>You can read about new features and bugfixes on our <a href="https://github.com/Soundofdarkness/RuneBook/releases">download page at Github</a></h3>
+
       <br><hr><br>
-      <p>That's all! Remember RuneBook is pretty much complete for what it has to offer, but it will always accept small contributions like these and it will still be updated to support the latest game patch.</p>
-      <h4 class="ui header right floated">OrangeNote, 2018-11-20</h4>
+      <p>Remember, RuneBook is pretty much complete for what it has to offer, but new small features might be added from time to time, and it will still be updated to support the latest game patch.</p>
+      <h4 class="ui header right floated"><a href="https://github.com/Soundofdarkness/RuneBook">RuneBook community</a></h4>
     </div>
   </div>
 


### PR DESCRIPTION
Shows modal with the link to download page, so that people can read changelogs there. Alternatively, update the text on every release.

![Greenshot 2020-06-09_21-41-59](https://user-images.githubusercontent.com/48414047/84186996-114a7800-aa9a-11ea-8dc1-c0059f031192.png)
