### PR TITLE
remove static rune mapping

### DIFF
--- a/plugins/championgg.js
+++ b/plugins/championgg.js
@@ -1,101 +1,12 @@
 var request = require('request');
 var cheerio = require('cheerio');
+const { getStylesMap, getPerksMapMap } = require('./utils');
 
 var url = "http://champion.gg";
 
-var stylesMap = {
-	"Precision":8000,
-	"Domination":8100,
-	"Sorcery":8200,
-	"Resolve":8400,
-	"Inspiration":8300
-};
-
-var perksMap = {
-    // Precision_Tier_1
-    "Press the Attack": 8005,
-    "Lethal Tempo": 8008,
-    "Fleet Footwork": 8021,
-    "Conqueror": 8010,
-    // Precision_Tier_2
-    "Overheal": 9101,
-    "Triumph": 9111,
-    "Presence of Mind": 8009,
-    // Precision_Tier_3
-    "Legend: Alacrity": 9104,
-    "Legend: Tenacity": 9105,
-    "Legend: Bloodline": 9103,
-    // Precision_Tier_4
-    "Coup de Grace": 8014,
-    "Cut Down": 8017,
-    "Last Stand": 8299,
-    // Domination_Tier_1
-    "Electrocute": 8112,
-    "Predator": 8124,
-    "Dark Harvest": 8128,
-    "Hail of Blades": 9923,
-    // Domination_Tier_2
-    "Cheap Shot": 8126,
-    "Taste of Blood": 8139,
-    "Sudden Impact": 8143,
-    // Domination_Tier_3
-    "Zombie Ward": 8136,
-    "Ghost Poro": 8120,
-    "Eyeball Collection": 8138,
-    // Domination_Tier_4
-    "Ravenous Hunter": 8135,
-    "Ingenious Hunter": 8134,
-    "Relentless Hunter": 8105,
-    "Ultimate Hunter": 8106,
-    // Sorcery_Tier_1
-    "Summon Aery": 8214,
-    "Arcane Comet": 8229,
-    "Phase Rush": 8230,
-    // Sorcery_Tier_2
-    "Nullifying Orb": 8224,
-    "Manaflow Band": 8226,
-    "Nimbus Cloak": 8275,
-    // Sorcery_Tier_3
-    "Transcendence": 8210,
-    "Celerity": 8234,
-    "Absolute Focus": 8233,
-    // Sorcery_Tier_4
-    "Scorch": 8237,
-    "Waterwalking": 8232,
-    "Gathering Storm": 8236,
-    // Resolve_Tier_1
-    "Grasp of the Undying": 8437,
-    "Aftershock": 8439,
-    "Guardian": 8465,
-    // Resolve_Tier_2
-    "Demolish": 8446,
-    "Font of Life": 8463,
-    "Shield Bash": 8401,
-    // Resolve_Tier_3
-    "Conditioning": 8429,
-    "Second Wind": 8444,
-    "Bone Plating": 8473,
-    // Resolve_Tier_4
-    "Overgrowth": 8451,
-    "Revitalize": 8453,
-    "Unflinching": 8242,
-    // Inspiration_Tier_1
-    "Glacial Augment": 8351,
-    "Unsealed Spellbook": 8360,
-    "Prototype: Omnistone": 8358,
-    // Inspiration_Tier_2
-    "Hextech Flashtraption": 8306,
-    "Magical Footwear": 8304,
-    "Perfect Timing": 8313,
-    // Inspiration_Tier_3
-    "Future's Market": 8321,
-    "Minion Dematerializer": 8316,
-    "Biscuit Delivery": 8345,
-    // Inspiration_Tier_4
-    "Cosmic Insight": 8347,
-    "Approach Velocity": 8410,
-    "Time Warp Tonic": 8352,
-    // Shards
+var stylesMap = {};
+var perksMap = {};
+var statsMap = {
     "Scaling Health": 5001,
     "Armor": 5002,
     "Magic Resist": 5003,
@@ -130,6 +41,8 @@ function exctractPage(html, champion, rec, callback, pageType) {
 				}
 			})
 		}
+
+		stylesMap = Object.keys(stylesMap).length == 0 ? getStylesMap() : stylesMap;
 		var rune = $(this).text();
 		rune = rune.replace(".png", "");
 		console.log(rune)
@@ -143,7 +56,9 @@ function exctractPage(html, champion, rec, callback, pageType) {
 		}
 		else runecount++;
 		
-		pages[pages.length - 1].selectedPerkIds[runecount % 9] = perksMap[rune];
+		perksMap = Object.keys(perksMap).length == 0 ? getPerksMapMap() : perksMap;
+		let perksMapMapped = Object.assign(perksMap, statsMap);
+		pages[pages.length - 1].selectedPerkIds[runecount % 9] = perksMapMapped[rune];
 	});
 
 	if(rec) {

--- a/plugins/metasrc.js
+++ b/plugins/metasrc.js
@@ -1,75 +1,13 @@
 var cheerio = require('cheerio');
 var rp = require('request-promise-native');
+const { getPerksMapMap } = require('./utils');
 
 const baseUrl = "https://www.metasrc.com/";
 const rankFilter = "?ranks=platinum,diamond,master,grandmaster,challenger";
 const modesToIgnore = ['tft'];
 
-var perksMap = {
-    "electrocute": 8112,
-    "predator": 8124,
-    "darkharvest": 8128,
-    "hailofblades": 9923,
-    "cheapshot": 8126,
-    "greenterror_tasteofblood": 8139,
-    "suddenimpact": 8143,
-    "zombieward": 8136,
-    "ghostporo": 8120,
-    "eyeballcollection": 8138,
-    "ravenoushunter": 8135,
-    "ingenioushunter": 8134,
-    "relentlesshunter": 8105,
-    "ultimatehunter": 8106,
-    "glacialaugment": 8351,
-    "unsealedspellbook": 8360,
-    "masterkey": 8358,
-    "hextechflashtraption": 8306,
-    "magicalfootwear": 8304,
-    "perfecttiming": 8313,
-    "futuresmarket": 8321,
-    "miniondematerializer": 8316,
-    "biscuitdelivery": 8345,
-    "cosmicinsight": 8347,
-    "approachvelocity": 8410,
-    "timewarptonic": 8352,
-    "presstheattack": 8005,
-    "lethaltempotemp": 8008,
-    "fleetfootwork": 8021,
-    "conqueror": 8010,
-    "overheal": 9101,
-    "triumph": 9111,
-    "presenceofmind": 8009,
-    "legendalacrity": 9104,
-    "legendtenacity": 9105,
-    "legendbloodline": 9103,
-    "coupdegrace": 8014,
-    "cutdown": 8017,
-    "laststand": 8299,
-    "graspoftheundying": 8437,
-    "veteranaftershock": 8439,
-    "guardian": 8465,
-    "demolish": 8446,
-    "fontoflife": 8463,
-    "mirrorshell": 8401,
-    "conditioning": 8429,
-    "secondwind": 8444,
-    "boneplating": 8473,
-    "overgrowth": 8451,
-    "revitalize": 8453,
-    "unflinching": 8242,
-    "summonaery": 8214,
-    "arcanecomet": 8229,
-    "phaserush": 8230,
-    "pokeshield": 8224,
-    "manaflowband": 8226,
-    "6361": 8275,
-    "transcendence": 8210,
-    "celeritytemp": 8234,
-    "absolutefocus": 8233,
-    "scorch": 8237,
-    "waterwalking": 8232,
-    "gatheringstorm": 8236,
-
+var perksMap = { };
+var statsMap = {
     "statmodshealthscalingicon": 5001,
     "statmodsarmoricon": 5002,
     "statmodsmagicresicon": 5003,
@@ -136,6 +74,17 @@ async function getPage(requestUri, champInfo) {
     return page;
 }
 
+function getPerksMap(){
+    if(Object.keys(perksMap).length == 0){
+        for (const [key, value] of Object.entries(getPerksMapMap('icon'))) {
+            var fileName = key.split('/').pop().replace(/\.[^/.]+$/, "");
+            perksMap[fileName.toLowerCase()] = value;
+          }
+    }
+    
+    return Object.assign(perksMap, statsMap);
+}
+
 function getIdFromImageUrl(url) {
     var perkId = -1;
 
@@ -144,7 +93,7 @@ function getIdFromImageUrl(url) {
     if (url.includes('perks')) {
         perkId = parseInt(fileName);
     } else {
-        perkId = perksMap[fileName];
+        perkId = getPerksMap()[fileName];
     }
 
     return perkId || -1;

--- a/plugins/runeforge.js
+++ b/plugins/runeforge.js
@@ -1,4 +1,6 @@
 var request = require('request');
+const { getStylesMap, getPerksMapMap } = require('./utils');
+
 var runeforge;
 var connected = false;
 
@@ -19,98 +21,12 @@ connect((res) => { connected = res; });
 
 var cheerio = require('cheerio');
 
-var stylesMap = {
-	"Precision":8000,
-	"Domination":8100,
-	"Sorcery":8200,
-	"Resolve":8400,
-	"Inspiration":8300
+var stylesMap = { };
+var perksMap = { 
+	"Coup De Grace": 8014,
+	"Future\u2019s Market": 8321
 };
-var perksMap = {
-    // Precision_Tier_1
-    "Press the Attack": 8005,
-    "Lethal Tempo": 8008,
-    "Fleet Footwork": 8021,
-    "Conqueror": 8010,
-    // Precision_Tier_2
-    "Overheal": 9101,
-    "Triumph": 9111,
-    "Presence of Mind": 8009,
-    // Precision_Tier_3
-    "Legend: Alacrity": 9104,
-    "Legend: Tenacity": 9105,
-    "Legend: Bloodline": 9103,
-    // Precision_Tier_4
-    "Coup De Grace": 8014,
-    "Cut Down": 8017,
-    "Last Stand": 8299,
-    // Domination_Tier_1
-    "Electrocute": 8112,
-    "Predator": 8124,
-    "Dark Harvest": 8128,
-    "Hail of Blades": 9923,
-    // Domination_Tier_2
-    "Cheap Shot": 8126,
-    "Taste of Blood": 8139,
-    "Sudden Impact": 8143,
-    // Domination_Tier_3
-    "Zombie Ward": 8136,
-    "Ghost Poro": 8120,
-    "Eyeball Collection": 8138,
-    // Domination_Tier_4
-    "Ravenous Hunter": 8135,
-    "Ingenious Hunter": 8134,
-    "Relentless Hunter": 8105,
-    "Ultimate Hunter": 8106,
-    // Sorcery_Tier_1
-    "Summon Aery": 8214,
-    "Arcane Comet": 8229,
-    "Phase Rush": 8230,
-    // Sorcery_Tier_2
-    "Nullifying Orb": 8224,
-    "Manaflow Band": 8226,
-    "Nimbus Cloak": 8275,
-    // Sorcery_Tier_3
-    "Transcendence": 8210,
-    "Celerity": 8234,
-    "Absolute Focus": 8233,
-    // Sorcery_Tier_4
-    "Scorch": 8237,
-    "Waterwalking": 8232,
-    "Gathering Storm": 8236,
-    // Resolve_Tier_1
-    "Grasp of the Undying": 8437,
-    "Aftershock": 8439,
-    "Guardian": 8465,
-    // Resolve_Tier_2
-    "Demolish": 8446,
-    "Font of Life": 8463,
-    "Shield Bash": 8401,
-    // Resolve_Tier_3
-    "Conditioning": 8429,
-    "Second Wind": 8444,
-    "Bone Plating": 8473,
-    // Resolve_Tier_4
-    "Overgrowth": 8451,
-    "Revitalize": 8453,
-    "Unflinching": 8242,
-    // Inspiration_Tier_1
-    "Glacial Augment": 8351,
-    "Unsealed Spellbook": 8360,
-    "Prototype: Omnistone": 8358,
-    // Inspiration_Tier_2
-    "Hextech Flashtraption": 8306,
-    "Magical Footwear": 8304,
-    "Perfect Timing": 8313,
-    // Inspiration_Tier_3
-    "Future\u2019s Market": 8321,
-    "Minion Dematerializer": 8316,
-    "Biscuit Delivery": 8345,
-    // Inspiration_Tier_4
-    "Cosmic Insight": 8347,
-    "Approach Velocity": 8410,
-    "Time Warp Tonic": 8352
-};
+var perksMapFixLen = Object.keys(perksMap).length;
 
 var shardsMap = {
 	"shard-health": 5001,
@@ -151,9 +67,11 @@ function exctractPage(html, pageUrl) {
         data.push($(this).attr("data-link-title"));
 	});
 
+	stylesMap = Object.keys(stylesMap).length == 0 ? getStylesMap() : stylesMap;
 	page.primaryStyleId = stylesMap[$("div.rune-path--primary .rune-path--path", path).attr("data-content-title")];
 	page.subStyleId = stylesMap[$("div.rune-path--secondary .rune-path--path", path).attr("data-content-title")];
 
+	perksMap = Object.keys(perksMap).length == perksMapFixLen ? Object.assign(perksMap, getPerksMapMap()) : perksMap;
     for (var i = 0; i < data.length; i++) {
 		page.selectedPerkIds[i] = perksMap[data[i]];
 	}

--- a/plugins/runeslol.js
+++ b/plugins/runeslol.js
@@ -1,5 +1,6 @@
 var cheerio = require('cheerio');
 var request = require('request');
+const { getStylesMap, getPerksMapMap } = require('./utils');
 
 var baseUrl = "https://runes.lol";
 var url = baseUrl + "/{gamemode}/platinum/plus/champion/{page}/{champion}/{role}";
@@ -8,98 +9,8 @@ var modePick = "pick";
 var gamemodeRanked = "ranked";
 var gamemodeAram = "aram";
 
-var stylesMap = {
-	"PRECISION":8000,
-	"DOMINATION":8100,
-	"SORCERY":8200,
-	"RESOLVE":8400,
-	"INSPIRATION":8300
-};
-var perksMap = {
-    // Precision_Tier_1
-    "Press the Attack": 8005,
-    "Lethal Tempo": 8008,
-    "Fleet Footwork": 8021,
-    "Conqueror": 8010,
-    // Precision_Tier_2
-    "Overheal": 9101,
-    "Triumph": 9111,
-    "Presence of Mind": 8009,
-    // Precision_Tier_3
-    "Legend: Alacrity": 9104,
-    "Legend: Tenacity": 9105,
-    "Legend: Bloodline": 9103,
-    // Precision_Tier_4
-    "Coup de Grace": 8014,
-    "Cut Down": 8017,
-    "Last Stand": 8299,
-    // Domination_Tier_1
-    "Electrocute": 8112,
-    "Predator": 8124,
-    "Dark Harvest": 8128,
-    "Hail of Blades": 9923,
-    // Domination_Tier_2
-    "Cheap Shot": 8126,
-    "Taste of Blood": 8139,
-    "Sudden Impact": 8143,
-    // Domination_Tier_3
-    "Zombie Ward": 8136,
-    "Ghost Poro": 8120,
-    "Eyeball Collection": 8138,
-    // Domination_Tier_4
-    "Ravenous Hunter": 8135,
-    "Ingenious Hunter": 8134,
-    "Relentless Hunter": 8105,
-    "Ultimate Hunter": 8106,
-    // Sorcery_Tier_1
-    "Summon Aery": 8214,
-    "Arcane Comet": 8229,
-    "Phase Rush": 8230,
-    // Sorcery_Tier_2
-    "Nullifying Orb": 8224,
-    "Manaflow Band": 8226,
-    "Nimbus Cloak": 8275,
-    // Sorcery_Tier_3
-    "Transcendence": 8210,
-    "Celerity": 8234,
-    "Absolute Focus": 8233,
-    // Sorcery_Tier_4
-    "Scorch": 8237,
-    "Waterwalking": 8232,
-    "Gathering Storm": 8236,
-    // Resolve_Tier_1
-    "Grasp of the Undying": 8437,
-    "Aftershock": 8439,
-    "Guardian": 8465,
-    // Resolve_Tier_2
-    "Demolish": 8446,
-    "Font of Life": 8463,
-    "Shield Bash": 8401,
-    // Resolve_Tier_3
-    "Conditioning": 8429,
-    "Second Wind": 8444,
-    "Bone Plating": 8473,
-    // Resolve_Tier_4
-    "Overgrowth": 8451,
-    "Revitalize": 8453,
-    "Unflinching": 8242,
-    // Inspiration_Tier_1
-    "Glacial Augment": 8351,
-    "Unsealed Spellbook": 8360,
-    "Prototype: Omnistone": 8358,
-    // Inspiration_Tier_2
-    "Hextech Flashtraption": 8306,
-    "Magical Footwear": 8304,
-    "Perfect Timing": 8313,
-    // Inspiration_Tier_3
-    "Future\'s Market": 8321,
-    "Minion Dematerializer": 8316,
-    "Biscuit Delivery": 8345,
-    // Inspiration_Tier_4
-    "Cosmic Insight": 8347,
-    "Approach Velocity": 8410,
-    "Time Warp Tonic": 8352
-};
+var stylesMap = {};
+var perksMap = {};
 
 function extractPage(html, pageName, pageUrl) {
 		
@@ -116,6 +27,9 @@ function extractPage(html, pageName, pageUrl) {
 	var keystones = [];
 	
 	$(".pure-u-8-24 > .runetitle").each(function() { keystones.push($(this).text()); });
+
+	stylesMap = Object.keys(stylesMap).length == 0 ? getStylesMap() : stylesMap;
+	perksMap = Object.keys(perksMap).length == 0 ? getPerksMapMap() : perksMap;
 
 	page.primaryStyleId = stylesMap[keystones[0]];
 	page.subStyleId = stylesMap[keystones[1]];

--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -5,22 +5,36 @@ function getJson(uri) {
   return rp({ uri, json: true });
 }
 
-// http://ddragon.leagueoflegends.com/cdn/8.23.1/data/en_US/runesReforged.json
-// tree = runes.reduce((obj, curr) => {
-//   obj[curr.id] = [].concat(...curr.slots.map(row => row.runes.map(i => i.id)));
-//   return obj;
-// }, {})
+function getStylesMap(usedKeyStr = 'name') {
+  let stylesMap = {};
+
+  freezer.get().runesreforgedinfo.forEach(runeInfo => {
+    stylesMap[runeInfo[usedKeyStr]] = runeInfo.id;
+  });
+
+  return stylesMap;
+}
+
+function getPerksMapMap(usedKeyStr = 'name') {
+  let perksMap = {};
+
+  freezer.get().runesreforgedinfo.forEach(runeInfo => {
+    [].concat(...runeInfo.slots.map(row => row.runes)).forEach(rune => {
+      perksMap[rune[usedKeyStr]] = rune.id;
+    });
+  });
+
+  return perksMap;
+}
+
 function sortRunes(runes, primaryStyle, subStyle) {
   const indexes = new Map();
   const sortingFunc = (a, b) => indexes.get(a) - indexes.get(b);
 
-  const tree = {
-    8000: [8005, 8008, 8021, 8010, 9101, 9111, 8009, 9104, 9105, 9103, 8014, 8017, 8299],
-    8100: [8112, 8124, 8128, 9923, 8126, 8139, 8143, 8136, 8120, 8138, 8135, 8134, 8105, 8106],
-    8200: [8214, 8229, 8230, 8224, 8226, 8275, 8210, 8234, 8233, 8237, 8232, 8236],
-    8300: [8351, 8360, 8358, 8306, 8304, 8313, 8321, 8316, 8345, 8347, 8410, 8352],
-    8400: [8437, 8439, 8465, 8446, 8463, 8401, 8429, 8444, 8473, 8451, 8453, 8242]
-  };
+  const tree = freezer.get().runesreforgedinfo.reduce((obj, curr) => {
+    obj[curr.id] = [].concat(...curr.slots.map(row => row.runes.map(i => i.id)));
+    return obj;
+  }, {});
   const styles = Object.keys(tree);
 
   const groupedRunes = groupBy(runes, rune => {
@@ -39,4 +53,4 @@ function sortRunes(runes, primaryStyle, subStyle) {
   return groupedRunes[primaryStyle].concat(groupedRunes[subStyle]);
 }
 
-module.exports = { getJson, sortRunes };
+module.exports = { getStylesMap, getPerksMapMap, getJson, sortRunes };

--- a/src/app.js
+++ b/src/app.js
@@ -91,6 +91,13 @@ request('https://ddragon.leagueoflegends.com/api/versions.json', function (error
 });
 
 freezer.on('version:set', (ver) => {
+	request('https://ddragon.leagueoflegends.com/cdn/'+ver+'/data/en_US/runesReforged.json', function(error, response, data) {
+		if(!error && response && response.statusCode == 200){
+			freezer.get().set('runesreforgedinfo', JSON.parse(data));
+		}
+		else throw Error("Couldn't fetch runesReforged.json from ddragon.")
+	});
+
 	request('https://ddragon.leagueoflegends.com/cdn/'+ver+'/data/en_US/champion.json', function(error, response, data) {
 		if(!error && response && response.statusCode == 200){
 			freezer.get().set('championsinfo', JSON.parse(data).data);

--- a/src/state.js
+++ b/src/state.js
@@ -54,7 +54,9 @@ var state = {
 		cwd: "[default path]"
 	},
 
+	// we could cache this information
 	championsinfo: {},
+	runesreforgedinfo: [],
 
 	lolversions: [],
 


### PR DESCRIPTION
This PR removes the static mappings of the runes.

To do this, the current version of Riot is pulled at startup and processed by two new functions, which should make maintenance easier.

Notes:

- The stat values (5001, 5002,5003,5005,5007,5008) are not included in the official json ([ref](https://github.com/RiotGames/developer-relations/issues/26)).Therefore they remain Static
- for runforge, 2 IDs had to remain static as well

PS: We should think about saving the Champ information and rune information locally so that we don't have to pull it every time we need to. Since they won't change during the patch anyway.
(But that has nothing to do with this PR)