### PR TITLE
Favpage autoupload bugfix

### DIFF
--- a/plugins/championgg.js
+++ b/plugins/championgg.js
@@ -45,7 +45,7 @@ function exctractPage(html, champion, rec, callback, pageType) {
 		stylesMap = Object.keys(stylesMap).length == 0 ? getStylesMap() : stylesMap;
 		var rune = $(this).text();
 		rune = rune.replace(".png", "");
-		console.log(rune)
+		//console.log(rune)
 		if(index % 11 == 0) {
 			pages[pages.length - 1].primaryStyleId = stylesMap[rune];
 			return;

--- a/plugins/local.js
+++ b/plugins/local.js
@@ -26,18 +26,18 @@ var plugin = {
 		else store.set(`local.${champion}.fav`, pagename);
 	},
 
-	deletePage(champion, page) {
-		console.log(champion, page)
-		page = page.replace(/\./g, '\\.');
-		store.delete(`local.${champion}.pages.${page}`);
-		if(store.get(`local.${champion}.fav`) == page) {
+	deletePage(champion, pagename) {
+		console.log(champion, pagename)
+		pagename = pagename.replace(/\./g, '\\.');
+		store.delete(`local.${champion}.pages.${pagename}`);
+		if(store.get(`local.${champion}.fav`) == pagename) {
 			store.set(`local.${champion}.fav`, null);
 		}
 	},
 
-	unlinkBookmark(champion, page) {
-		page = page.replace(/\./g, '\\.');
-		store.delete(`local.${champion}.pages.${page}.bookmark`);
+	unlinkBookmark(champion, pagename) {
+		pagename = pagename.replace(/\./g, '\\.');
+		store.delete(`local.${champion}.pages.${pagename}.bookmark`);
 	},
 
 	setPage(champion, page) {
@@ -46,8 +46,8 @@ var plugin = {
 		store.set(`local.${champion}.pages`, pages);
 	},
 
-	confirmPageValidity(champion, page, res) {
-		page = page.replace(/\./g, '\\.');
+	confirmPageValidity(champion, pagename, res) {
+		pagename = pagename.replace(/\./g, '\\.');
 		/*
 		 * If the page returned is invalid, mark it as such in the store.
 		 * This behaviour is not predictable (a page can become invalid at any time),
@@ -55,14 +55,14 @@ var plugin = {
 		 */
 		if(res.isValid === false) {
 			console.log("Warning: page incomplete or malformed.");
-			store.set(`local.${champion}.pages.${page}.isValid`, false);
+			store.set(`local.${champion}.pages.${pagename}.isValid`, false);
 		}
 		/*
 		 * If the page returned is valid, but we have an invalid copy in the store,
 		 * then replace the local page with the updated one.
 		 */
-		else if(store.get(`local.${champion}.pages.${page}.isValid`) === false) {
-			store.set(`local.${champion}.pages.${page}`, res);
+		else if(store.get(`local.${champion}.pages.${pagename}.isValid`) === false) {
+			store.set(`local.${champion}.pages.${pagename}`, res);
 		}
 	}
 }

--- a/src/state.js
+++ b/src/state.js
@@ -60,7 +60,10 @@ var state = {
 
 	lolversions: [],
 
-	champselect: false,
+	champselect: {
+		active: false,
+		favuploaded: false
+	},
 	autochamp: false,
 
 	tooltips: {

--- a/src/state.js
+++ b/src/state.js
@@ -4,7 +4,6 @@ var state = {
 	session: {
 		connected: false,
 		state: ""
-
 	},
 
 	connection: {
@@ -62,7 +61,8 @@ var state = {
 
 	champselect: {
 		active: false,
-		favuploaded: false
+		gameMode: null,
+		favUploaded: false,
 	},
 	autochamp: false,
 

--- a/tags/select-champion.tag
+++ b/tags/select-champion.tag
@@ -9,7 +9,7 @@
             <img draggable="false" class="ui tiny image circular"
               src={opts.champion ? `https://ddragon.leagueoflegends.com/cdn/${freezer.get().lolversions[0]}/img/champion/${this.opts.champion}.png` : "./img/unknown.png"}>
             <img draggable="false" class="ui tiny-ring image circular" style="position: absolute; top: -2px; left: 12px;" src={opts.autochamp ? "./img/ring_active.png" : "./img/ring.png"}>
-            <img if={ opts.autochamp && opts.champselect } draggable="false" class="ui tiny-spin image circular" style="position: absolute; top: -10px; left: 4px;" src="./img/ring_spinner.png">
+            <img if={ opts.autochamp && opts.champselect.active } draggable="false" class="ui tiny-spin image circular" style="position: absolute; top: -10px; left: 4px;" src="./img/ring_spinner.png">
           </div>
           
           <div class="column middle aligned">


### PR DESCRIPTION
1. Fixes a bug, introduced in #41, where favorite page would be uploaded multiple times per champ select. Now it's done properly - only one upload after champion is locked in.

2. Disables favpage autoupload in all modes except classic Rift (ranked, draft & blind pick). In ARAM this feature only does harm by rewriting runepages after every champion swap.

3. Fixes some inconsistent variable naming in app.js, where `page` was used to represent both `pagedata` and `pagename` i