### PR TITLE
removed need for primaryStyleId and subStyleId

### DIFF
--- a/plugins/blitzgg.js
+++ b/plugins/blitzgg.js
@@ -104,9 +104,7 @@ function getPage(runesJson, champInfo, gameMode) {
         // Return rune page
         return {
             name: `[${gameMode.name}] ${champInfo.name} ${runesJson.role}`.trim(),
-            primaryStyleId: primaryStyleId,
             selectedPerkIds: selectedPerkIds,
-            subStyleId: subStyleId,
             bookmark: {
                 champId: champInfo.id,
                 gameModeKey: gameMode.key,

--- a/plugins/blitzgg.js
+++ b/plugins/blitzgg.js
@@ -92,14 +92,8 @@ function getPage(runesJson, champInfo, gameMode) {
         const perksData = runesJson["stats"]["most_common_runes"]["build"];
         const statShards = runesJson["stats"]["most_common_rune_stat_shards"]["build"];
 
-        // Get ID of primary style and sub styles
-        const primaryStyleId = perksData[0];
-        const subStyleId = perksData[5];
-
         // Determine selected perk ids
-        const selectedPerkIds = sortRunes(perksData, primaryStyleId, subStyleId).concat(
-            statShards
-        );
+        const selectedPerkIds = sortRunes(perksData).concat(statShards);
 
         // Return rune page
         return {

--- a/plugins/koreanbuilds.js
+++ b/plugins/koreanbuilds.js
@@ -29,9 +29,7 @@ function extractPage(html, champObj, champion, role, rec, callback, pageType) {
 		if(index % 11 == 0) {
 			pages.push({
 				"name": champObj.name + " " + role + " BC "+ $('#circle-big').text(),
-				"primaryStyleId": -1,
 				"selectedPerkIds": [0, 0, 0, 0, 0, 0],
-				"subStyleId": -1,
 				// "bookmark": {
 				// 	"src": url + "/champion/" + champion + "/" + role + "/" + champObj.version.replace(/\.(?:[0-9]*)$/, '') + '/-1',
 				// 	"meta": {
@@ -52,10 +50,6 @@ function extractPage(html, champObj, champion, role, rec, callback, pageType) {
 		var secondary = $('#reforged-secondary .perk-img-c').attr("src");
 		secondary = secondary.replace("//statics.koreanbuilds.net/perk-types/", "");
 		secondary = secondary.replace(".png", "");
-		if(index % 9 == 0) {
-			pages[pages.length - 1].primaryStyleId = stylesMap[primary];
-			pages[pages.length - 1].subStyleId = stylesMap[secondary];
-		}
 		pages[pages.length - 1].selectedPerkIds[index] = parseInt(rune);
 	});
 

--- a/plugins/lolalytics.js
+++ b/plugins/lolalytics.js
@@ -1,5 +1,5 @@
 const rp = require('request-promise-native');
-const { sortRunes, getStyleId } = require('./utils');
+const { sortRunes } = require('./utils');
 
 // #region Settings
 const supported_modes = [{
@@ -81,18 +81,12 @@ function getPage(runesJson, champInfo, gameMode, position, runesMode) {
         const perksPriData = runesJson["set"]["pri"];
         const perksSecData = runesJson["set"]["sec"];
         const statShards = runesJson["set"]["mod"];
-
-        // Get ID of primary style and sub styles
-        const primaryStyleId = getStyleId(perksPriData);
-        const subStyleId = getStyleId(perksSecData);
     
         // Merge all runes
-        const perksData = [].concat(primaryStyleId, perksPriData, subStyleId, perksSecData);
+        const perksData = [].concat(perksPriData, perksSecData, statShards);
 
         // Determine selected perk ids
-        const selectedPerkIds = sortRunes(perksData.concat(statShards), primaryStyleId, subStyleId).concat(
-            statShards
-        );
+        const selectedPerkIds = sortRunes(perksData).concat(statShards);
 
         // Determine the name of the position
         let positionString = gameMode.positions.length <= 1 ? '' : position;

--- a/plugins/lolalytics.js
+++ b/plugins/lolalytics.js
@@ -102,9 +102,7 @@ function getPage(runesJson, champInfo, gameMode, position, runesMode) {
         // Return rune page
         return {
             name: `[${gameMode.name}] ${champInfo.name} ${positionString} - ${runesModeMap[runesMode]}`.trim(),
-            primaryStyleId: primaryStyleId,
             selectedPerkIds: selectedPerkIds,
-            subStyleId: subStyleId,
             bookmark: {
                 champId: champInfo.id,
                 gameModeKey: gameMode.key,

--- a/plugins/lolalytics.js
+++ b/plugins/lolalytics.js
@@ -83,7 +83,7 @@ function getPage(runesJson, champInfo, gameMode, position, runesMode) {
         const statShards = runesJson["set"]["mod"];
     
         // Merge all runes
-        const perksData = [].concat(perksPriData, perksSecData, statShards);
+        const perksData = [].concat(perksPriData, perksSecData);
 
         // Determine selected perk ids
         const selectedPerkIds = sortRunes(perksData).concat(statShards);

--- a/plugins/lolalytics.js
+++ b/plugins/lolalytics.js
@@ -90,7 +90,7 @@ function getPage(runesJson, champInfo, gameMode, position, runesMode) {
         const perksData = [].concat(primaryStyleId, perksPriData, subStyleId, perksSecData);
 
         // Determine selected perk ids
-        const selectedPerkIds = sortRunes(perksData, primaryStyleId, subStyleId).concat(
+        const selectedPerkIds = sortRunes(perksData.concat(statShards), primaryStyleId, subStyleId).concat(
             statShards
         );
 

--- a/plugins/metasrc.js
+++ b/plugins/metasrc.js
@@ -19,9 +19,7 @@ var statsMap = {
 async function getPage(requestUri, champInfo) {
     var page = {
         "name": name,
-        "primaryStyleId": -1,
         "selectedPerkIds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
-        "subStyleId": -1,
         "bookmark": {
             "src": requestUri,
             "remote": {
@@ -56,12 +54,10 @@ async function getPage(requestUri, champInfo) {
 
         var ids = $('svg > image[data-xlink-href]').map((i, x) => getIdFromImageUrl($(x).attr('data-xlink-href'))).toArray();
 
-        page['primaryStyleId'] = ids[0];
         page.selectedPerkIds[0] = ids[1];
         page.selectedPerkIds[1] = ids[2];
         page.selectedPerkIds[2] = ids[3];
         page.selectedPerkIds[3] = ids[4];
-        page['subStyleId'] = ids[5];
         page.selectedPerkIds[4] = ids[6];
         page.selectedPerkIds[5] = ids[7];
         page.selectedPerkIds[6] = ids[8];

--- a/plugins/metasrc.js
+++ b/plugins/metasrc.js
@@ -1,6 +1,6 @@
 var cheerio = require('cheerio');
 var rp = require('request-promise-native');
-const { getPerksMapMap } = require('./utils');
+const { getPerksMap } = require('./utils');
 
 const baseUrl = "https://www.metasrc.com/";
 const rankFilter = "?ranks=platinum,diamond,master,grandmaster,challenger";
@@ -74,9 +74,9 @@ async function getPage(requestUri, champInfo) {
     return page;
 }
 
-function getPerksMap(){
+function _getPerksMap(){
     if(Object.keys(perksMap).length == 0){
-        for (const [key, value] of Object.entries(getPerksMapMap('icon'))) {
+        for (const [key, value] of Object.entries(getPerksMap('icon'))) {
             var fileName = key.split('/').pop().replace(/\.[^/.]+$/, "");
             perksMap[fileName.toLowerCase()] = value;
           }
@@ -93,7 +93,7 @@ function getIdFromImageUrl(url) {
     if (url.includes('perks')) {
         perkId = parseInt(fileName);
     } else {
-        perkId = getPerksMap()[fileName];
+        perkId = _getPerksMap()[fileName];
     }
 
     return perkId || -1;

--- a/plugins/opgg.js
+++ b/plugins/opgg.js
@@ -21,11 +21,6 @@ function extractRunePagesFromElement($, champion, position) {
 
     const name = `${champion} ${upperFirst(position)} PR${stats[0]} WR${stats[1]}`;
 
-    const styles = $(runePageElement)
-      .find('.champion-overview__data .perk-page .perk-page__item--mark img')
-      .map(getPerkIdFromImg)
-      .get();
-
     // normal runes
     let selectedPerkIds = $(runePageElement)
       .find('.champion-overview__data .perk-page .perk-page__item--active img')
@@ -42,9 +37,7 @@ function extractRunePagesFromElement($, champion, position) {
 
     return {
       name,
-      primaryStyleId: styles[0],
-      subStyleId: styles[1],
-      selectedPerkIds,
+      selectedPerkIds: selectedPerkIds,
       bookmark: {
         src: url + champion + '/statistics/' + position,
         meta: {

--- a/plugins/ugg.js
+++ b/plugins/ugg.js
@@ -143,14 +143,8 @@ function getPage(runesJson, champInfo, position, gameMode) {
         const perksData = runesJsonModed[u.stats.perks];
         const statShards = runesJsonModed[u.stats.statShards][u.shards.stats].map(str => parseInt(str, 10));
 
-        // Get ID of primary style and sub styles
-        const primaryStyleId = perksData[u.perks.mainPerk];
-        const subStyleId = perksData[u.perks.subPerk];
-
         // Determine selected perk ids
-        const selectedPerkIds = sortRunes(perksData[u.perks.perks], primaryStyleId, subStyleId).concat(
-            statShards
-        );
+        const selectedPerkIds = sortRunes(perksData[u.perks.perks]).concat(statShards);
 
         // Return rune page
         return {

--- a/plugins/ugg.js
+++ b/plugins/ugg.js
@@ -155,9 +155,7 @@ function getPage(runesJson, champInfo, position, gameMode) {
         // Return rune page
         return {
             name: `[${gameMode.name}] ${champInfo.name} ${u.positionsReversed[position]}`.trim(),
-            primaryStyleId: primaryStyleId,
             selectedPerkIds: selectedPerkIds,
-            subStyleId: subStyleId,
             bookmark: {
                 champId: champInfo.id,
                 gameModeKey: gameMode.key,

--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -1,12 +1,22 @@
 const rp = require('request-promise-native');
 const { groupBy } = require('lodash');
 
+/**
+ * Gets a JSON object from a URI via 'request-promise-native'.
+ * @param {string} uri - URI from which the json is to be retrieved
+ * @return {object} JSON object what were received from the uri
+ */
 function getJson(uri) {
   return rp({ uri, json: true });
 }
 
+/**
+ * Returns a list of runes styles with ID as value.
+ * @param {string} usedKeyStr - The value to be used as key. Default is 'name'
+ * @return {object} A list of rune styles with the respective ID as value.
+ */
 function getStylesMap(usedKeyStr = 'name') {
-  let stylesMap = {};
+  const stylesMap = {};
 
   freezer.get().runesreforgedinfo.forEach(runeInfo => {
     stylesMap[runeInfo[usedKeyStr]] = runeInfo.id;
@@ -15,8 +25,13 @@ function getStylesMap(usedKeyStr = 'name') {
   return stylesMap;
 }
 
-function getPerksMapMap(usedKeyStr = 'name') {
-  let perksMap = {};
+/**
+ * Returns a list of rune perks with ID as value.
+ * @param {string} usedKeyStr - The value to be used as key. Default is 'name'
+ * @return {object} A list of rune perks with the respective ID as value.
+ */
+function getPerksMap(usedKeyStr = 'name') {
+  const perksMap = {};
 
   freezer.get().runesreforgedinfo.forEach(runeInfo => {
     [].concat(...runeInfo.slots.map(row => row.runes)).forEach(rune => {
@@ -27,31 +42,47 @@ function getPerksMapMap(usedKeyStr = 'name') {
   return perksMap;
 }
 
+/**
+ * Returns the rune style id based on the passed rune ids.
+ * @param {Array} runes - A list of runes ids
+ * @return {number} Runic style ID that could be determined. If no ID could be determined -1 is returned.
+ */
 function getStyleId(runes) {
   let styleId = -1;
 
   freezer.get().runesreforgedinfo.forEach(runeInfo => {
-      var runeIds = ([].concat(...runeInfo.slots.map(row => row.runes))).map(rune => rune.id)
-      if (runes.every(v => runeIds.includes(v)) === true)
-          styleId = runeInfo.id;
+    const runeIds = new Set(([].concat(...runeInfo.slots.map(row => row.runes))).map(rune => rune.id))
+    if (runes.every(v => runeIds.has(v)) === true)
+        styleId = runeInfo.id;
   });
 
   return styleId;
 }
 
+/**
+ * Sortiert die Runen so wie sie auch im Spiele sind.
+ * @param {Array} runes - A list of runes ids
+ * @param {number} primaryStyle - Style Id of the primary runes
+ * @param {number} subStyle - Style Id of the secondary runes
+ * @return {Array} Sorted list of runes
+ */
 function sortRunes(runes, primaryStyle, subStyle) {
+  // Index map for later sorting
   const indexes = new Map();
+
+  // Sorting function that sorts the runes based on the index in the tree
   const sortingFunc = (a, b) => indexes.get(a) - indexes.get(b);
 
+  // Creates a tree of style id and the matching runes
   const tree = freezer.get().runesreforgedinfo.reduce((obj, curr) => {
     obj[curr.id] = [].concat(...curr.slots.map(row => row.runes.map(i => i.id)));
     return obj;
   }, {});
-  const styles = Object.keys(tree);
 
-  const groupedRunes = groupBy(runes, rune => {
-    for (style of styles) {
-      let runeIndex = tree[style].indexOf(rune);
+  // Groups the passed runes fit to the respective style id
+  const groupedRunes = groupBy(runes, (rune) => {
+    for (const style of Object.keys(tree)) {
+      const runeIndex = tree[style].indexOf(rune);
       if (runeIndex !== -1) {
         indexes.set(rune, runeIndex);
         return style;
@@ -59,10 +90,13 @@ function sortRunes(runes, primaryStyle, subStyle) {
     }
   });
 
+  // Sorts the groups for the respective style
   groupedRunes[primaryStyle].sort(sortingFunc);
   groupedRunes[subStyle].sort(sortingFunc);
 
+  // Merges primary and secondary runes in the correct order
   return groupedRunes[primaryStyle].concat(groupedRunes[subStyle]);
 }
 
-module.exports = { getStylesMap, getPerksMapMap, getStyleId, getJson, sortRunes };
+// Transfer of functions for use in other modules
+module.exports = { getStylesMap, getPerksMap, getStyleId, getJson, sortRunes };


### PR DESCRIPTION
I have removed the need for primaryStyleId and subStyleId in sortRunes. Additionally I removed "primaryStyleId" and "subStyleId" from the runes page as well, since they were never used (I think this is an artifact from old times). And finally I added some documentation to utils.js.