### PR TITLE
fix for #88

### DIFF
--- a/plugins/ugg.js
+++ b/plugins/ugg.js
@@ -1,5 +1,5 @@
 const rp = require('request-promise-native');
-const { removePerkIds, sortRunes } = require('./utils');
+const { removePerkIds } = require('./utils');
 
 // #region U.GG API consts
 const u = {
@@ -142,9 +142,7 @@ function getPage(runesJson, champInfo, position, gameMode) {
         const statShards = runesJsonModed[u.stats.statShards][u.shards.stats].map(str => parseInt(str, 10));
 
         // Determine selected perk ids
-        const perksSorted = sortRunes(removePerkIds(perksData[u.perks.perks]));
-        const selectedPerkIds = perksSorted.concat(statShards);
-        // console.log(selectedPerkIds);
+        const selectedPerkIds = removePerkIds(perksData[u.perks.perks]).concat(statShards);
 
         // Return rune page
         return {

--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -51,47 +51,5 @@ function removePerkIds(runes) {
   return runes.filter(el => !perkIds.includes(el));
 }
 
-/**
- * Sorts a rune array to the correct order for displaying
- * (probably horribly coded, I just dont see a better way atm)
- * Most of the map functions are just used to flatten the runes reforged info to just id's
- * @param {Array<Number>} runes - An array of potentially unsorted rune id's
- * @returns {Array<Number>} A sorted rune array suitable for displaying it on the UI
- */
-function sortRunes(runes){
-  const info = freezer.get().runesreforgedinfo;
-
-  const runeSorted = [];
-
-
-  // Determine Keystone (effectively just add all keystone ids to a single array and then check if any rune id matches one of the keystones)
-  const keystones = info.map(x => x.slots[0].runes.map(y => y.id));
-  const keystone = runes.find(x => keystones.flat().includes(x));
-  runeSorted.push(keystone);
-  runes = runes.filter(x => x != keystone);
-
-  // Determine primary perks
-  // First trying to find the type (Domination, etc) and then just loop through each slot and find the fitting rune and add it to the sorted rune page
-  const primaryType = info.find(x => x.slots[0].runes.map(y => y.id).includes(keystone));
-  primaryType.slots.forEach(x => {
-    const perk = runes.find(y => x.runes.map(z => z.id).includes(y));
-    if(!perk) return;
-    runeSorted.push(perk);
-    runes = runes.filter(x => x != perk);
-  });
-
-  // Determine secondary type
-  // pretty much the same code as on primary, just the way of finding the type is a bit more complex
-  const secondaryType = info.find(x => x.slots.map(y => y.runes.map(z => z.id)).flat().includes(runes[0]));
-  secondaryType.slots.forEach(x => {
-    const perk = runes.find(y => x.runes.map(z => z.id).includes(y));
-    if(!perk) return;
-    runeSorted.push(perk);
-    runes = runes.filter(x => x != perk);
-  })
-
-  return runeSorted;
-}
-
 // Transfer of functions for use in other modules
-module.exports = { getStylesMap, getPerksMap, getJson, removePerkIds, sortRunes };
+module.exports = { getStylesMap, getPerksMap, getJson, removePerkIds };


### PR DESCRIPTION
That should fix #88. I undid the old changes and solved it as follows:

All returns from "getPages" are centrally chased through a wrapper. So we have a central possibility to make changes to the returns of the pages. Conceivable would be sorting by name or similar.

But currently only one new property is added and that is the prepared rune page that will be sent to LoL later. Since this wide correctly sorted runes has this then also to the property is passed which is used for the display etc..

This should fix the problem not only for u.gg but for all plugins  (in case it occurs again).