### PR TITLE
dont use jquery for external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
         this.on('update', function() {
             let markup = opts.data;
             if (!markup) return;
-            let html = marked(markup);
-            this.root.innerHTML = html;
+            let renderer = new marked.Renderer();
+            renderer.link = ( href, title, text ) => `<a target="_blank" href="${ href }" title="${ title }">${ text }</a>`;
+            this.root.innerHTML = marked(markup, { renderer });
         })
     });
   </script>

--- a/src/app.js
+++ b/src/app.js
@@ -476,13 +476,6 @@ freezer.on("autochamp:disable", () => {
 	settings.set("autochamp", false);
 });
 
-var shell = require('electron').shell;
-//open links externally by default
-$(document).on('click', 'a[href^="http"]', function(event) {
-	event.preventDefault();
-	shell.openExternal(this.href);
-});
-
 const LCUConnector = require('lcu-connector');
 console.log("config leaguepath", freezer.get().configfile.leaguepath)
 console.log("config pathdiscovery", freezer.get().configfile.pathdiscovery)

--- a/src/main.js
+++ b/src/main.js
@@ -84,6 +84,12 @@ function createWindow() {
         win.show();
     });
 
+    // ToDo: if we upgrade to Electron 12: https://stackoverflow.com/questions/32402327/how-can-i-force-external-links-from-browser-window-to-open-in-a-default-browser/67409223#67409223
+    win.webContents.on('new-window', function(e, url) {
+        e.preventDefault();
+        require('electron').shell.openExternal(url);
+      });
+
     // Open the DevTools.
     // win.webContents.openDevTools()
 

--- a/tags/changelog-modal.tag
+++ b/tags/changelog-modal.tag
@@ -11,12 +11,12 @@
       <h4 class="centered">RuneBook has been updated to version { require('electron').remote.app.isPackaged === false ? "DEV" : require('electron').remote.app.getVersion(); }</h4>
 
       <p><markup data={freezer.get().changelogbody}></markup></p>
-      <p if={ !freezer.get().changelogbody }>You can read about new features and bugfixes on our <a href="https://github.com/Soundofdarkness/RuneBook/releases">download page at Github</a></p>
+      <p if={ !freezer.get().changelogbody }>You can read about new features and bugfixes on our <a href="https://github.com/Soundofdarkness/RuneBook/releases" target="_blank">download page at Github</a></p>
       
       <div class="ui divider"></div>
 
       <p>Remember, RuneBook is pretty much complete for what it has to offer, but new small features might be added from time to time, and it will still be updated to support the latest game patch.</p>
-      <h4 class="ui header right floated"><a href="https://github.com/Soundofdarkness/RuneBook">RuneBook community</a></h4>
+      <h4 class="ui header right floated"><a href="https://github.com/Soundofdarkness/RuneBook" target="_blank">RuneBook community</a></h4>
     </div>
   </div>
 

--- a/tags/settings-panel.tag
+++ b/tags/settings-panel.tag
@@ -4,8 +4,7 @@
       <div class="ui bottom attached label footer">
         RuneBook <a onclick="$('.changelog-modal').modal('show')">{ require('electron').remote.app.isPackaged === false ? "DEV" :
           require('electron').remote.app.getVersion(); }</a>
-        <span style="float: right;"><a href="https://github.com/Soundofdarkness/RuneBook/issues"
-            style="color: #555555;"><i class="bug icon"></i></a></span>
+        <span style="float: right;"><a href="https://github.com/Soundofdarkness/RuneBook/issues" target="_blank" style="color: #555555;"><i class="bug icon"></i></a></span>
       </div>
       <div class="ui form">
         <div class="grouped fields">
@@ -148,13 +147,13 @@
             <div class="column">
               <div class="field">
                 <span>
-                  <i1-8n>settings.madeby</i1-8n> <a href="https://github.com/OrangeNote/Runebook">OrangeNote</a>
+                  <i1-8n>settings.madeby</i1-8n> <a href="https://github.com/OrangeNote/Runebook" target="_blank">OrangeNote</a>
                 </span>
               </div>
             </div>
             <div class="column">
               <div class="field">
-                <span>Maintained by <a href="https://github.com/Soundofdarkness/Runebook">Community</a></span>
+                <span>Maintained by <a href="https://github.com/Soundofdarkness/Runebook" target="_blank">Community</a></span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
The old variant needs JQuery and because I want to remove JQuery (currently "semantic-ui-css" is still the blocker, but there it will be worked on (or you could switch to "fomantic-ui-css" if they are faster).

But anyway. This PR removes the old variant and replaces it with a better one that has no dependency.

Remark: external URL's must contain ``target="_blank``.