### PR TITLE
Fix undefined page on blitz plugin

### DIFF
--- a/plugins/blitzgg.js
+++ b/plugins/blitzgg.js
@@ -166,7 +166,7 @@ function getPage(runesJson, champInfo, queue, role) {
  */
 async function getPagesForGameModeAsync(champInfo, queue, role) {
     // Return variable (List of rune pages)
-    var returnVal = {};
+    var returnVal = null;
     try {
         // get json for the given champ and game mode
         var result = await getChampionsJsonAsync(champInfo.key, queue, role);
@@ -206,11 +206,11 @@ async function _getPagesAsync(champion, callback) {
         for (const gameMode of supported_modes){
             if (gameMode.role == null){
                 page = await getPagesForGameModeAsync(champInfo, gameMode.queue,null)
-                runePages.pages[page.name] = page
+                if (page) { runePages.pages[page.name] = page }
             }else{
                 for (const role of gameMode.role){
                     page = await getPagesForGameModeAsync(champInfo, gameMode.queue, role)
-                    runePages.pages[page.name] = page
+                    if (page) { runePages.pages[page.name] = page }
                 }
             }
         }


### PR DESCRIPTION
Fixes #135 

Hello ! 
Here is a fix for the blitz.gg plugin. There is a bug when there is no page fetched for a game mode and a role (i.e. Ahri jungle in ranked mode). It creates an `undefined` key => value in the `runePages` object which lead to this error :

![image](https://github.com/Soundofdarkness/RuneBook/assets/26260538/9be399ee-0d35-419a-abfe-0f6d0705b641)

The fix is to return a `null` value when no page is fetched and add only non `null` value in the `runePages` object